### PR TITLE
Allow server address reuse

### DIFF
--- a/server.py
+++ b/server.py
@@ -30,6 +30,7 @@ def start_server():
         os.chdir(script_dir)
         
         # Buat server
+        socketserver.TCPServer.allow_reuse_address = True
         with socketserver.TCPServer((HOST, PORT), CustomHTTPRequestHandler) as httpd:
             print(f"🎰 SpinWheels Server dimulai!")
             print(f"📍 URL: http://{HOST}:{PORT}")


### PR DESCRIPTION
## Summary
- configure `socketserver.TCPServer` to allow address reuse before instantiation

## Testing
- `python3 server.py & sleep 1; kill $!`

------
https://chatgpt.com/codex/tasks/task_e_68403aa4260c8322a2d0f86850b2d5fb